### PR TITLE
Change image tag in 02-logo.md

### DIFF
--- a/docs/_includes/02-logo.md
+++ b/docs/_includes/02-logo.md
@@ -1,1 +1,1 @@
-<img src="../_images/ruhrpottmetaller_logo.jpeg" align="right" width="150" hight="150" alt="Ruhrpottmetaller logo">
+![Ruhrpottmetaller logo](../_images/ruhrpottmetaller_logo.jpeg)


### PR DESCRIPTION
Change the image tag from html based to markdown based. This may solve an error in the project's github page. 02-using.md is included there.