### PR TITLE
Change link to LICENSE from relative to absolute.

### DIFF
--- a/docs/_includes/07-license.md
+++ b/docs/_includes/07-license.md
@@ -1,3 +1,3 @@
 # License
-This work is provided unter the terms of the MIT license. Please take a look at the [LICENSE](../../LICENSE)
+This work is provided unter the terms of the MIT license. Please take a look at the [LICENSE](https://github.com/klaus-thorres/rpmetaller-editor/blob/master/LICENSE)
 file for the full text.


### PR DESCRIPTION
Changed the link to the license file from relative to absolute, because the absolute one does not work.